### PR TITLE
Create peggy grammar to replace hand-rolled parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules/
 dist/
 bench/
+parser/generated_parser.js
+.idea

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "prepublish": "npm run build",
     "build": "run-script-os",
     "build:win32": "rm -rf dist && rollup index.js --config cjs.config.js && rollup index.js --config esm.config.js && echo { \"type\": \"module\" } > dist/esm/package.json && echo { \"type\": \"commonjs\" } > dist/cjs/package.json && cd dist && exitzero standard --fix */*.js && tsc ../index.js --declaration --allowJs --emitDeclarationOnly --target ESNext --moduleResolution node",
-    "build:default": "rm -rf dist && rollup index.js --config cjs.config.js && rollup index.js --config esm.config.js && echo '{ \"type\": \"module\" }' > dist/esm/package.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json && cd dist && exitzero standard --fix */*.js && tsc ../index.js --declaration --allowJs --emitDeclarationOnly --target ESNext --moduleResolution node"
+    "build:default": "rm -rf dist && rollup index.js --config cjs.config.js && rollup index.js --config esm.config.js && echo '{ \"type\": \"module\" }' > dist/esm/package.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json && cd dist && exitzero standard --fix */*.js && tsc ../index.js --declaration --allowJs --emitDeclarationOnly --target ESNext --moduleResolution node",
+    "generate:parser": "peggy -o parser/generated_parser.js parser/grammar.pegjs"
   },
   "dependencies": {
     "date-fns": "^2.23.0",
@@ -29,6 +30,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "exitzero": "^1.0.1",
+    "peggy": "^1.2.0",
     "rollup": "^2.58.3",
     "run-script-os": "^1.1.6",
     "standard": "^16.0.4",

--- a/parser/grammar.pegjs
+++ b/parser/grammar.pegjs
@@ -1,0 +1,216 @@
+{
+  String.prototype.stripEscape = function(seq) { return this.replace(`\\${seq}`, seq); }
+
+  function reduceArithmetic(head, tail) {
+    return [head, ...tail].reduce((acc, val) => {
+      if (acc == null) {
+        return val;
+      }
+
+      const operator = val[1];
+      const rightHandSide = val[3]
+      return { [operator]: [acc, rightHandSide] }
+    }, null)
+  }
+}
+
+
+//
+// Documents
+//
+
+Document
+  = Operations
+
+//
+// Operations
+//
+
+Operations
+  = _ head:Fork _                                            { return [head];          }
+  / _ head:Split _                                           { return head;            }
+  / _ head:Operation _ OperationDelimiter _ tail:Operations  { return [head, ...tail]; }
+  / _ head:Operation _ OperationDelimiter                    { return [head];          }
+
+Operation
+  = op:Operator _req exps:Operands OperationDelimiter { return { operator: op, expressions: exps } }
+  / op:Operator OperationDelimiter                    { return { operator: op, expressions: []   } }
+Operator
+  = id:Identifier { return id }
+Operands
+  = _ exp:Expression _ "," _ tail:Operands { return [exp, ...tail] }
+  / _ exp:Expression { return [ exp ]; }
+OperationDelimiter
+  = ';'
+  / '\n'?
+
+
+
+Split
+  = _ '>>' doc:Document '<<' {
+      return [
+        { split: doc },
+        { operator: 'mergeAll' }
+      ]
+    }
+
+
+
+Fork
+  = _ 'fork' _req type:Identifier _ '>>' _ body:ForkBody _ '<<' {
+      return { fork: body, type: type }
+  }
+ForkBody
+  = _ '(' _ head:Document _ ')' tail:ForkBody* { return [head, ...(tail || [])] }
+
+
+
+//
+// Expressions
+//
+
+Expression "expression"
+  = ArithmeticExpression
+  / FunctionCall
+  / NonArithmeticExpression
+NonArithmeticExpression
+  = Object
+  / Array
+  / Boolean
+  / VarIdentifier
+  / ContextIdentifier
+  / String
+  / Numeric
+
+
+
+ArithmeticExpression = ArithmeticExpression9
+ArithmeticExpression9
+  = head:ArithmeticExpression8 tail:(_ '||' _ val:ArithmeticExpression8)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression8
+ArithmeticExpression8
+  = head:ArithmeticExpression7 tail:(_ '&&' _ val:ArithmeticExpression7)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression7
+ArithmeticExpression7
+  = head:ArithmeticExpression6 tail:(_ ('!==' / '!=' / '===' / '==') _ val:ArithmeticExpression6)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression6
+ArithmeticExpression6
+  = head:ArithmeticExpression5 tail:(_ ('<=' / '<' / '>' / '>=') _ val:ArithmeticExpression5)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression5
+ArithmeticExpression5
+  = head:ArithmeticExpression4 tail:(_ ('+' / '-') _ val:ArithmeticExpression4)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression4
+ArithmeticExpression4
+  = head:ArithmeticExpression3 tail:(_ '%' _ val:ArithmeticExpression3)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression3
+ArithmeticExpression3
+  = head:ArithmeticExpression2 tail:(_ ('*' / '/') _ val:ArithmeticExpression2)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression2
+ArithmeticExpression2
+  = head:ArithmeticExpression1 tail:(_ '**' _ val:ArithmeticExpression1)+
+    { return reduceArithmetic(head, tail); }
+  / ArithmeticExpression1
+ArithmeticExpression1
+  = op:('!' / '+' / '-') head:ArithmeticExpression0
+    { return { [op]: head } }
+  / ArithmeticExpression0
+ArithmeticExpression0
+  = _ "(" _ exp:Expression _ ")" { return exp; }
+  / NonArithmeticExpression
+
+
+
+FunctionCall
+  = _ id:Identifier _ '(' _ args:FunctionArgs _ ')' {
+    return { [id]: args }
+  }
+FunctionArgs
+  = head:Expression _ "," _ tail:(FunctionArgs) { return [head, ...tail]; }
+  / head:Expression _ ","?                      { return [head]; }
+
+
+//
+// Literals
+//
+
+Object "object"
+  = _ "{" _ body:(ObjectEntry*) _ "}" {
+    return { obj: body.flat() }
+  }
+ObjectEntry "object-entry"
+  = pair:ObjectEntryPair _ "," _ tail:(ObjectEntry) { return [ ...pair, ...tail ] }
+  / pair:ObjectEntryPair _ ","?                     { return pair                 }
+ObjectEntryPair
+  = _ key:ObjectKey _ ":" _ val:Expression { return [key, val]; }
+ObjectKey
+  = Identifier
+  / Expression
+
+
+
+Array "array"
+  = _ "[" _ body:(ArrayEntry*) _ "]" { return { list: body } }
+ArrayEntry
+  = value:Expression _ "," _ tail:(ArrayEntry) { return [value, ...tail] }
+  / value:Expression _ ","?					   { return [value]          }
+
+
+
+Identifier "identifier"
+  = [a-zA-Z_]+ [a-zA-Z_-]* { return text() }
+  / '@' id:Identifier { return text() }
+  / '$' id:Identifier { return text() }
+VarIdentifier "@-identifier"
+  = "@." id:MemberIdentifier { return { var: id } }
+  / "@" { return { var: '' } }
+ContextIdentifier "$-identifier"
+  = '$.' id:MemberIdentifier { return { context: id } }
+  / "$" { return { context: '' } }
+MemberIdentifier "member-identifier"
+  = Identifier
+  / Integer { return text() }
+
+
+
+String "string"
+  = '"' value:(DoubleQuotedStringContents*) '"' { return value.join(''); }
+  / "'" value:(SingleQuotedStringContents*) "'" { return value.join(''); }
+DoubleQuotedStringContents
+  = '\\"' { return text().stripEscape('"'); }
+  / [^"]
+SingleQuotedStringContents
+  = "\\'" { return text().stripEscape("'") }
+  / [^']
+
+
+
+Boolean
+  = 'true' { return true; }
+  / 'false' { return false; }
+
+
+
+Numeric
+  = _ [0-9]* "." [0-9]+ { return Number(text()) }
+  / _ [0-9]+ "." [0-9]* { return Number(text()) }
+  / Integer
+Integer 'integer'
+  = _ [0-9]+ { return Number(text()) }
+
+
+//
+// Whitespace
+//
+
+_req "required whitespace"
+  = [ \t\n\r]+
+
+_ "optional whitespace"
+  = [ \t\n\r]*

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,6 +1254,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+peggy@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/peggy/-/peggy-1.2.0.tgz#657ba45900cbef1dc9f52356704bdbb193c2021c"
+  integrity sha512-PQ+NKpAobImfMprYQtc4Egmyi29bidRGEX0kKjCU5uuW09s0Cthwqhfy7mLkwcB4VcgacE5L/ZjruD/kOPCUUw==
+
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"


### PR DESCRIPTION
* Include new `parser/grammar.pegjs` that fully specifies the language and returns the pre-existing AST
* Add `peggy` dev dependency
* Add `generate:parser` script that generates `parser/generated_parser.js`
* Added generated file to gitignore

Have fun with a much cleaner & easier to extend grammar! (Not to mention, hopefully better error messages when things go wrong!)